### PR TITLE
Move string strip in serialize_row

### DIFF
--- a/fm_data_tasks/utils/data_utils.py
+++ b/fm_data_tasks/utils/data_utils.py
@@ -33,7 +33,7 @@ def serialize_row(
         if str(row[c_og]) == "nan":
             row[c_og] = nan_tok
         else:
-            row[c_og] = f"{row[c_og].strip()}"
+            row[c_og] = f"{row[c_og]}".strip()
         res.append(f"{c_map}: {row[c_og]}".lstrip())
     if len(sep_tok) > 0 and sep_tok != ".":
         sep_tok = f" {sep_tok}"


### PR DESCRIPTION
I'm using 
- Python version 3.10.4
- Pandas version 1.4.4

and was running into an issue with the example run script from the Readme:
```bash
python3 -m fm_data_tasks.run_inference \
    --dry_run \
    --num_run 10 \
    --k 3 \
    --sample_method random \
    --data_dir data/datasets/entity_matching/structured/Fodors-Zagats
```

errors out with

```bash
AttributeError: 'int' object has no attribute 'strip'
```

Since the row value is not always a string. 

Moving the strip to outside the string format should fix this.