### PR TITLE
[fix] unblock example pipeline from README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.1.0
+      rev: v4.4.0
       hooks:
           - id: trailing-whitespace
           - id: end-of-file-fixer
@@ -9,16 +9,16 @@ repos:
           - id: check-merge-conflict
           - id: check-added-large-files
     - repo: https://github.com/timothycrosley/isort
-      rev: 5.10.1
+      rev: 5.12.0
       hooks:
           - id: isort
     - repo: https://github.com/psf/black
-      rev: 22.3.0
+      rev: 23.3.0
       hooks:
           - id: black
             language_version: python3
-    - repo: https://gitlab.com/pycqa/flake8
-      rev: 3.9.2
+    - repo: https://github.com/pycqa/flake8.git
+      rev: 6.0.0
       hooks:
           - id: flake8
             additional_dependencies: [flake8-docstrings]

--- a/fm_data_tasks/utils/data_utils.py
+++ b/fm_data_tasks/utils/data_utils.py
@@ -33,7 +33,7 @@ def serialize_row(
         if str(row[c_og]) == "nan":
             row[c_og] = nan_tok
         else:
-            row[c_og] = f"{row[c_og].strip()}"
+            row[c_og] = f"{row[c_og]}".strip()
         res.append(f"{c_map}: {row[c_og]}".lstrip())
     if len(sep_tok) > 0 and sep_tok != ".":
         sep_tok = f" {sep_tok}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ datasets = "^2.1.0"
 transformers = "^4.18.0"
 torch = "^1.8"
 black = "^22.3.0"
-isort = "^5.10.1"
+isort = "^5.12.0"
 sklearn = "^0.0"
 argh = "^0.26.2"
 wandb = "^0.12.14"
@@ -27,7 +27,7 @@ flake8 = "^4.0.1"
 pre-commit = "^2.19.0"
 sqlitedict = "^2.0.0"
 sentence-transformers = "^2.2.0"
-
+manifest-ml = "^0.1.5"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Unblock the example pipeline from README.md from c954cfdac6a420f773553e19dbfda81fba25df14. Also, update pre-commit dependencies.

Changes:
1. Fix an error with pandas datatype for numeric entries. The same error was fixed in another pull request: https://github.com/HazyResearch/fm_data_tasks/pull/5.
2. Changed the flake8 link to point to GitHub since it was moved from GitLab.
3. Update isort and other related packages that caused conflict with poetry.
Error: `RuntimeError: The Poetry configuration is invalid:
            - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'`